### PR TITLE
fix: Ensure the right ARCH is used for versions > 0.2.1

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -47,8 +47,8 @@ download_release() {
   ALTARCH=$(uname -m)
   ALTOS=$(uname -s)
 
-  # Okta has changed from x86_64 to amd64 for Darwin starting from 0.3.0 (why? something I don't know?) so we need to adapt
-  if [[ "${ARCH}" == "x86_64" && "${ASDF_INSTALL_VERSION}" == "0.3.0" ]]; then
+  # Okta has changed from x86_64 to amd64 from 0.3.0 (why? something I don't know?) so we need to adapt
+  if [[ "${ARCH}" == "x86_64" && ! "${ASDF_INSTALL_VERSION}" =~ ^0\.[012]\.* ]]; then
     ALTARCH=amd64
   fi
   if [[ "${OS}" == "Linux" ]]; then


### PR DESCRIPTION
All subsequent versions from 0.3.0 use amd64 instead of x86_64. So need to ensure the correct ARCH is set.