### PR TITLE
Fix amd64 reference to newer releases

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -47,8 +47,8 @@ download_release() {
   ALTARCH=$(uname -m)
   ALTOS=$(uname -s)
 
-  # Okta has changed from x86_64 to amd64 for Darwin starting from 0.3.0 (why? something I don't know?) so we need to adapt
-  if [[ "${ARCH}" == "x86_64" && "${ASDF_INSTALL_VERSION}" == "0.3.0" ]]; then
+  # Okta used x86_64 instead of amd64 for 0.2.0 and 0.2.1 release, so we need to adapt
+  if [[ "${ARCH}" == "x86_64" && ( "${ASDF_INSTALL_VERSION}" != "0.2.0" || "${ASDF_INSTALL_VERSION}" != "0.2.1" ) ]]; then
     ALTARCH=amd64
   fi
   if [[ "${OS}" == "Linux" ]]; then


### PR DESCRIPTION
This change fixes the release fetching error when trying to install latest releases:

```
asdf install okta-aws-cli latest
* Downloading okta-aws-cli release 1.2.2...
curl: (22) The requested URL returned error: 404
asdf-okta-aws-cli: Could not download https://github.com/okta/okta-aws-cli/releases/download/v1.2.2/okta-aws-cli_1.2.2_linux_x86_64.tar.gz
```
