### PR TITLE
fix(asdf-okta-aws-cli):  Fix install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.github/.DS_Store

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -86,7 +86,8 @@ install_version() {
   (
     mkdir -p "$install_path"
     cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
-    cp -p "${install_path}/${tool_cmd}_v${version}" "${install_path}/${tool_cmd}"
+    # This is failing in April 2025 - not sure since when nor why
+    #cp -p "${install_path}/${tool_cmd}_v${version}" "${install_path}/${tool_cmd}"
 
     # TODO: Assert okta-aws-cli executable exists.
     local tool_cmd


### PR DESCRIPTION
Installation was broken, I don't know since when and I have not worked out why.
It looks like the format of the `okta-aws-cli` binary has changed inside the tar file.
